### PR TITLE
Update for Slate v0.25.0

### DIFF
--- a/lib/focusAtEnd.js
+++ b/lib/focusAtEnd.js
@@ -4,10 +4,11 @@
  * @param  {Slate.Transform} transform
  * @return {Slate.Transform}
  */
-function focusAtEnd(transform) {
-    const { state } = transform;
-    const { document } = state;
-    return transform.collapseToEndOf(document);
+function focusAtEnd(change) {
+  var {state} = change;
+  var document = state.document;
+  change.collapseToEndOf(document);
+  return true
 }
 
 module.exports = focusAtEnd;

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,14 +27,15 @@ function TrailingBlock(opts) {
                         return (!lastNode || !opts.match(lastNode)) ?
                             true : null;
                     },
-                    normalize(transform, node, value) {
+                    normalize(change, node, value) {
                         const lastIndex = node.nodes.count();
                         const block = Slate.Block.create({
                             type: opts.type,
                             nodes: [Slate.Text.create()]
                         });
 
-                        return transform.insertNodeByKey(node.key, lastIndex, block);
+                        change.insertNodeByKey(node.key, lastIndex, block);
+                        return true
                     }
                 }
             ]


### PR DESCRIPTION
`transform` is renamed to `change` since v0.25.0 in Slate