### PR TITLE
feat: update slate to ^0.32.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ function TrailingBlock(opts) {
 
     return {
         validateNode: (node) => {
-            if (node.kind !== 'document') {
+            if (node.object !== 'document') {
                 return undefined;
             }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "git://github.com/GitbookIO/slate-trailing-block.git",
   "main": "./dist/index.js",
   "peerDependencies": {
-    "slate": "^0.33.0"
+    "slate": "^0.32.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
@@ -20,7 +20,7 @@
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "read-metadata": "^1.0.0",
-    "slate": "^0.32.0"
+    "slate": "^0.33.0"
   },
   "scripts": {
     "prepublish": "babel ./lib --out-dir ./dist",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "git://github.com/GitbookIO/slate-trailing-block.git",
   "main": "./dist/index.js",
   "peerDependencies": {
-    "slate": "^0.29.0"
+    "slate": "^0.33.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
@@ -20,7 +20,7 @@
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "read-metadata": "^1.0.0",
-    "slate": "^0.29.0"
+    "slate": "^0.33.0"
   },
   "scripts": {
     "prepublish": "babel ./lib --out-dir ./dist",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "read-metadata": "^1.0.0",
-    "slate": "^0.33.0"
+    "slate": "^0.32.0"
   },
   "scripts": {
     "prepublish": "babel ./lib --out-dir ./dist",

--- a/tests/ensure-trailing-multi/expected.yaml
+++ b/tests/ensure-trailing-multi/expected.yaml
@@ -2,21 +2,21 @@
 
 document:
   nodes:
-  - kind: block
+  - object: block
     type: heading
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: My Title
-  - kind: block
+  - object: block
     type: code_block
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: Some code
-  - kind: block
+  - object: block
     type: paragraph
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: ""

--- a/tests/ensure-trailing-multi/input.yaml
+++ b/tests/ensure-trailing-multi/input.yaml
@@ -2,15 +2,15 @@
 
 document:
   nodes:
-  - kind: block
+  - object: block
     type: heading
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: My Title
-  - kind: block
+  - object: block
     type: code_block
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: Some code

--- a/tests/ensure-trailing-other/expected.yaml
+++ b/tests/ensure-trailing-other/expected.yaml
@@ -2,15 +2,15 @@
 
 document:
   nodes:
-  - kind: block
+  - object: block
     type: heading
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: My Title
-  - kind: block
+  - object: block
     type: footnote
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: My Title

--- a/tests/ensure-trailing-other/input.yaml
+++ b/tests/ensure-trailing-other/input.yaml
@@ -2,16 +2,16 @@
 
 document:
   nodes:
-  - kind: block
+  - object: block
     type: heading
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: My Title
-  - kind: block
+  - object: block
     # in unit tests, footnotes and paragraphs are matches for valid trailing block
     type: footnote
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: My Title

--- a/tests/ensure-trailing/expected.yaml
+++ b/tests/ensure-trailing/expected.yaml
@@ -2,15 +2,15 @@
 
 document:
   nodes:
-  - kind: block
+  - object: block
     type: heading
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: My Title
-  - kind: block
+  - object: block
     type: paragraph
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: ""

--- a/tests/ensure-trailing/input.yaml
+++ b/tests/ensure-trailing/input.yaml
@@ -2,9 +2,9 @@
 
 document:
   nodes:
-  - kind: block
+  - object: block
     type: heading
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: My Title

--- a/tests/just-the-trailing-block/expected.yaml
+++ b/tests/just-the-trailing-block/expected.yaml
@@ -2,9 +2,9 @@
 
 document:
   nodes:
-  - kind: block
+  - object: block
     type: paragraph
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: ''

--- a/tests/just-the-trailing-block/input.yaml
+++ b/tests/just-the-trailing-block/input.yaml
@@ -1,9 +1,9 @@
 
 document:
   nodes:
-  - kind: block
+  - object: block
     type: paragraph
     nodes:
-      - kind: text
+      - object: text
         leaves:
           - text: ''

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,13 +2189,17 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate-dev-logger@^0.1.25:
-  version "0.1.32"
-  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.32.tgz#76b73d75a149d0eac0cab134965aca14f7542888"
+slate-dev-logger@^0.1.39:
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
 
-slate@^0.29.0:
-  version "0.29.1"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.29.1.tgz#a9df98158e67f92456b9b8f38fb6d279ba8f9f7e"
+slate-schema-violations@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.4.tgz#f87ad4091f72c66edf32f418a33d80e5e87ad5e8"
+
+slate@^0.33.0:
+  version "0.33.0"
+  resolved "http://registry.npmjs.org/slate/-/slate-0.33.0.tgz#6a4e084aa3a55dc5b09bce1b7037f284396b9160"
   dependencies:
     debug "^2.3.2"
     direction "^0.1.5"
@@ -2203,7 +2207,8 @@ slate@^0.29.0:
     is-empty "^1.0.0"
     is-plain-object "^2.0.4"
     lodash "^4.17.4"
-    slate-dev-logger "^0.1.25"
+    slate-dev-logger "^0.1.39"
+    slate-schema-violations "^0.1.4"
     type-of "^2.0.1"
 
 slice-ansi@0.0.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,13 +2193,13 @@ slate-dev-logger@^0.1.39:
   version "0.1.39"
   resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
 
-slate-schema-violations@^0.1.3:
+slate-schema-violations@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.7.tgz#cf2c6156eaf545f4d1985d3d1b94c50d6d273a08"
 
-slate@^0.32.0:
-  version "0.32.5"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.32.5.tgz#5386c75dec1e5b87648189c9fbb4294cec623ff0"
+slate@^0.33.0:
+  version "0.33.3"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.33.3.tgz#e9eb2f7c2740a46d45eb7b60c1f4da6699285878"
   dependencies:
     debug "^2.3.2"
     direction "^0.1.5"
@@ -2208,7 +2208,7 @@ slate@^0.32.0:
     is-plain-object "^2.0.4"
     lodash "^4.17.4"
     slate-dev-logger "^0.1.39"
-    slate-schema-violations "^0.1.3"
+    slate-schema-violations "^0.1.7"
     type-of "^2.0.1"
 
 slice-ansi@0.0.4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2193,13 +2193,13 @@ slate-dev-logger@^0.1.39:
   version "0.1.39"
   resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.39.tgz#744a69b85034244713e6de51483af5713c345af4"
 
-slate-schema-violations@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.4.tgz#f87ad4091f72c66edf32f418a33d80e5e87ad5e8"
+slate-schema-violations@^0.1.3:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/slate-schema-violations/-/slate-schema-violations-0.1.7.tgz#cf2c6156eaf545f4d1985d3d1b94c50d6d273a08"
 
-slate@^0.33.0:
-  version "0.33.0"
-  resolved "http://registry.npmjs.org/slate/-/slate-0.33.0.tgz#6a4e084aa3a55dc5b09bce1b7037f284396b9160"
+slate@^0.32.0:
+  version "0.32.5"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.32.5.tgz#5386c75dec1e5b87648189c9fbb4294cec623ff0"
   dependencies:
     debug "^2.3.2"
     direction "^0.1.5"
@@ -2208,7 +2208,7 @@ slate@^0.33.0:
     is-plain-object "^2.0.4"
     lodash "^4.17.4"
     slate-dev-logger "^0.1.39"
-    slate-schema-violations "^0.1.4"
+    slate-schema-violations "^0.1.3"
     type-of "^2.0.1"
 
 slice-ansi@0.0.4:


### PR DESCRIPTION
Updates slate to current version. Mostly consists of changing `kind` to `object`. Resolves #7.